### PR TITLE
Only load Valine if it's enabled in the config.

### DIFF
--- a/layout/partials/head.ejs
+++ b/layout/partials/head.ejs
@@ -68,6 +68,8 @@ if (is_archive()){
 <% } %>
 
 <%# valine comment support %>
-<script src='https://unpkg.com/valine@1.4.16/dist/Valine.min.js'></script>
+<% if(theme.valine.enable){ %>
+    <script src='https://unpkg.com/valine@1.4.16/dist/Valine.min.js'></script>
+<% } %>
 
 


### PR DESCRIPTION
At the moment, the theme will load Valine's JavaScript file regardless of whether the user has enabled or disabled it in the config.
This is a simple couple line fix to stop that from happening when Valine is disabled in `_config.yml`.