### PR TITLE
Update post_head.ejs

### DIFF
--- a/layout/post/post_head.ejs
+++ b/layout/post/post_head.ejs
@@ -25,10 +25,6 @@
         </span>
     </div>
     <div class="post-img">
-        <% if (page.featured_image) {%>
-            <img src="<%= url_for(page.featured_image)%>" alt="featured_image">
-        <% } else { %>
             <div class="h-line-primary"></div>
-        <% } %>      
     </div>
 </div>


### PR DESCRIPTION
不在正文中展示封面图，图片还有可能在放大后失帧，影响美观

而且，如果用户引入目录，还将影响排版

不管是那种情况，这不是一个艺术的设计，可以考虑在内容正文移除封面图的选项